### PR TITLE
Add transaction_id to ProcessingReport

### DIFF
--- a/src/transactions/ProcessingReport.php
+++ b/src/transactions/ProcessingReport.php
@@ -26,6 +26,14 @@ class ProcessingReport extends AbstractJSONWrapper
     public $queued;
     
     /**
+     * The identifier of the transaction.
+     * Available when generated automatically (generate_transaction_id=true) or generated externally
+     *
+     * @var string
+     */
+    public $transaction_id;
+    
+    /**
      * The error message (if there was any)
      *
      * @var string


### PR DESCRIPTION
https://support.maileon.com/support/create-transactions/

The transaction_id (if available in the response) is not taken into account.