### PR TITLE
fix(media): CUI-275: add missing size property to Template

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Date 2026-08-20
+Version 1.25.3
+- Fixed Template missing size property, causing "Undefined property: Template::$size" during template hydration
+
 Date 2026-06-02
 Version 1.25.2
 - Added getTemplates(), getTemplate(), and getTemplateAsZip() media methods

--- a/src/media/Template.php
+++ b/src/media/Template.php
@@ -18,6 +18,9 @@ class Template extends AbstractJSONWrapper
     /** @var string|null */
     protected $created;
 
+    /** @var int|null */
+    protected $size;
+
     /** @var string[]|null */
     protected $tags = [];
 
@@ -39,6 +42,11 @@ class Template extends AbstractJSONWrapper
     public function getCreated()
     {
         return $this->created;
+    }
+
+    public function getSize()
+    {
+        return $this->size;
     }
 
     public function getTags()

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-dist.version = 1.25.2
-dist.version.stable = 1.25.2
+dist.version = 1.25.3
+dist.version.stable = 1.25.3


### PR DESCRIPTION
## Summary
- Maileon's media templates API (getTemplates/getCms2MailingTemplates) returns a `size` field per template that `de\xqueue\maileon\api\client\media\Template` never declared.
- `AbstractJSONWrapper::fromArray()` reads `$this->{$key}` for every key in the API response, so hydrating a `Template` from a response containing `size` raised `Undefined property: Template::$size`, breaking template hydration in consumer apps (surfaced as an upload failure in the Breuninger briefing uploader in cross-account-data-manager).
- Added `protected $size` (`int|null`) and `getSize()` to `Template`, matching the existing property/getter style.
- Bumped `version.txt` to 1.25.3 and added a CHANGELOG entry.

## Test plan
- [ ] Verify `getTemplates()`/`getCms2MailingTemplates()` responses containing a `size` field hydrate without warnings
- [ ] `composer update xqueue/maileon-api-client` in cross-account-data-manager once merged/tagged, confirm Breuninger upload flow no longer fails