### PR TITLE
fix(media): CUI-275: add missing mimetype property to Template

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 Date 2026-08-20
+Version 1.25.4
+- Fixed Template missing mimetype property, causing "Undefined property: Template::$mimetype" during template hydration
+
+Date 2026-08-20
 Version 1.25.3
 - Fixed Template missing size property, causing "Undefined property: Template::$size" during template hydration
 

--- a/src/media/Template.php
+++ b/src/media/Template.php
@@ -21,6 +21,9 @@ class Template extends AbstractJSONWrapper
     /** @var int|null */
     protected $size;
 
+    /** @var string|null */
+    protected $mimetype;
+
     /** @var string[]|null */
     protected $tags = [];
 
@@ -47,6 +50,11 @@ class Template extends AbstractJSONWrapper
     public function getSize()
     {
         return $this->size;
+    }
+
+    public function getMimetype()
+    {
+        return $this->mimetype;
     }
 
     public function getTags()

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-dist.version = 1.25.3
-dist.version.stable = 1.25.3
+dist.version = 1.25.4
+dist.version.stable = 1.25.4


### PR DESCRIPTION
## Summary
- Follow-up to #32. Checked the server-side model (`MediaLibElement`, eagle commit 9d2c0fd8) and it added both `size` and `mimetype` in the same change — the v1.25.3 fix only covered `size`.
- `mimetype` is `@JsonInclude(NON_NULL)` server-side, so it's present in the response for essentially every real template, meaning `getTemplates()`-based hydration would still hit `Undefined property: Template::$mimetype`.
- Added `protected $mimetype` (`string|null`) and `getMimetype()` to `Template`.
- Bumped `version.txt` to 1.25.4, added CHANGELOG entry.

## Test plan
- [ ] Verify `getTemplates()` responses hydrate without warnings now that both `size` and `mimetype` are declared
- [ ] `composer update xqueue/maileon-api-client` in cross-account-data-manager once merged/tagged