### PR TITLE
fix(media): CUI-275: add missing size and mimetype properties to Article

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 Date 2026-08-20
+Version 1.25.5
+- Fixed Article missing size and mimetype properties, causing "Undefined property: Article::$size"/"$mimetype" during article hydration (media/articles is backed by the same server-side model as media/templates)
+
+Date 2026-08-20
 Version 1.25.4
 - Fixed Template missing mimetype property, causing "Undefined property: Template::$mimetype" during template hydration
 

--- a/src/media/Article.php
+++ b/src/media/Article.php
@@ -18,6 +18,12 @@ class Article extends AbstractJSONWrapper
     /** @var string|null */
     protected $created;
 
+    /** @var int|null */
+    protected $size;
+
+    /** @var string|null */
+    protected $mimetype;
+
     /** @var string[]|null */
     protected $tags = [];
 
@@ -39,6 +45,16 @@ class Article extends AbstractJSONWrapper
     public function getCreated()
     {
         return $this->created;
+    }
+
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    public function getMimetype()
+    {
+        return $this->mimetype;
     }
 
     public function getTags()

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-dist.version = 1.25.4
-dist.version.stable = 1.25.4
+dist.version = 1.25.5
+dist.version.stable = 1.25.5


### PR DESCRIPTION
## Summary
- `MedialibArticleResource` (backing `media/articles`) uses the same shared server-side `MediaLibElement` model as `MediaTemplateResource` (fixed for `Template` in #32/#33).
- `Article` never declared `size`/`mimetype` either, so `getArticles()`/`getArticle()` would hit the identical "Undefined property" bug once the response includes those fields.
- Added `protected $size` (`int|null`) and `protected $mimetype` (`string|null`) with getters, matching `Template`.
- Bumped `version.txt` to 1.25.5, added CHANGELOG entry.

## Test plan
- [ ] Verify `getArticles()`/`getArticle()` responses hydrate without warnings